### PR TITLE
Fix View conversion

### DIFF
--- a/convert_torch.py
+++ b/convert_torch.py
@@ -77,7 +77,7 @@ def lua_recursive_model(module,seq):
             n = nn.UpsamplingNearest2d(scale_factor=m.scale_factor)
             add_submodule(seq,n)
         elif name == 'View':
-            n = Lambda(lambda x,s=m.size: x.view(s))
+            n = Lambda(lambda x: x.view(x.size(0),-1))
             add_submodule(seq,n)
         elif name == 'Linear':
             # Linear in pytorch only accept 2D input
@@ -161,7 +161,7 @@ def lua_recursive_source(module):
         elif name == 'SpatialUpSamplingNearest':
             s += ['nn.UpsamplingNearest2d(scale_factor={})'.format(m.scale_factor)]
         elif name == 'View':
-            s += ['Lambda(lambda x,s={}: x.view(s)), # View'.format(m.size)]
+            s += ['Lambda(lambda x: x.view(x.size(0),-1)), # View']
         elif name == 'Linear':
             s1 = 'Lambda(lambda x: x.view(1,-1) if 1==len(x.size()) else x )'
             s2 = 'nn.Linear({},{},bias={})'.format(m.weight.size(1),m.weight.size(0),(m.bias is not None))


### PR DESCRIPTION
The older version produced a flattened version of the input tensor including batch dimension.
Specifically, given the 'pool5' output tensor of VGG16 net, i.e. batch_size x 512 x 7 x 7:
* older version (Lambda(lambda x,s=torch.Size([-1]): x.view(s))): batch_size * 512 * 7 * 7
* new version (Lambda(lambda x: x.view(x.size(0),-1))): batch_size x 512 * 7 * 7

Thank you for your script